### PR TITLE
Move secure module declaration from application.conf to dependencies.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ eclipse
 .classpath
 *.zip
 *~
+logs
+test-result

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ before_install:
 before_script: 
   # create spatially-enabled database
   - psql -c 'create database gtfs_editor;' -U postgres
-  - psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis-1.5/postgis.sql
-  - psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis-1.5/spatial_ref_sys.sql
-  - psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis_comments.sql
+  - sudo -u postgres psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis-1.5/postgis.sql
+  - sudo -u postgres psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis-1.5/spatial_ref_sys.sql
+  - sudo -u postgres psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis_comments.sql
   # get play framework
   - wget http://download.playframework.org/releases/play-${PLAY_VERSION}.zip
   - unzip -q play-${PLAY_VERSION}.zip 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - postgresql
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -qq postgresql-9.1-postgis
+  - sudo apt-get install -qq postgis
 before_script: 
   # create spatially-enabled database
   - psql -c 'create database gtfs_editor;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 services:
   - postgresql
 before_install:
-  - echo "yes" | sudo apt-add-repository ppa:ubuntugis/ubuntugis-stable
+  - sudo add-apt-repository ppa:ubuntugis/ppa
   - sudo apt-get update -qq
   - sudo apt-get install -qq postgis
 before_script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: scala # to trigger the build on JVM worker ('language: java' works the same)
+env:
+  - PLAY_VERSION=1.2.5
+before_script: 
+  - wget http://download.playframework.org/releases/play-${PLAY_VERSION}.zip
+  - unzip -q play-${PLAY_VERSION}.zip 
+script: play-${PLAY_VERSION}/play test
+notifications:
+  # Email notifications are disabled to not annoy anybody.
+  # See http://about.travis-ci.org/docs/user/build-configuration/ to learn more
+  # about configuring notification recipients and more.
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: scala # to trigger the build on JVM worker ('language: java' works the same)
 env:
   - PLAY_VERSION=1.2.5
-  - POSTGIS=2.0
 services:
   - postgresql
 before_install:
-  - sudo add-apt-repository ppa:ubuntugis/ppa
+  - echo "yes" | sudo add-apt-repository ppa:ubuntugis/ppa
   - sudo apt-get update -qq
   - sudo apt-get install -qq postgis
 before_script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 before_install:
   - echo "yes" | sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libgeos-dev libgeos++-dev libproj-dev postgresql-9.1-postgis
+  - sudo apt-get install -qq postgresql-9.1-postgis
 before_script: 
   # create spatially-enabled database
   - psql -c 'create database gtfs_editor;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ env:
 services:
   - postgresql
 before_install:
-  - echo "yes" | sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable
+  - echo "yes" | sudo apt-add-repository ppa:ubuntugis/ubuntugis-stable
   - sudo apt-get update -qq
-  - sudo apt-get install -qq postgresql-9.1-postgis
+  - sudo apt-get install -qq postgis
 before_script: 
   # create spatially-enabled database
   - psql -c 'create database gtfs_editor;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
 language: scala # to trigger the build on JVM worker ('language: java' works the same)
 env:
   - PLAY_VERSION=1.2.5
+services:
+  - postgresql
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq postgresql-9.1-postgis
 before_script: 
+  # create spatially-enabled database
+  - psql -c 'create database gtfs_editor;' -U postgres
+  - psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis-1.5/postgis.sql
+  - psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis-1.5/spatial_ref_sys.sql
+  - psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis_comments.sql
+  # get play framework
   - wget http://download.playframework.org/releases/play-${PLAY_VERSION}.zip
   - unzip -q play-${PLAY_VERSION}.zip 
+  # copy over config file
+  - cp conf/application.conf.template conf/application.conf
 script: play-${PLAY_VERSION}/play test
 notifications:
   # Email notifications are disabled to not annoy anybody.

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - unzip -q play-${PLAY_VERSION}.zip 
   # copy over config file
   - cp conf/application.conf.template conf/application.conf
-script: play-${PLAY_VERSION}/play test
+script: play-${PLAY_VERSION}/play auto-test
 notifications:
   # Email notifications are disabled to not annoy anybody.
   # See http://about.travis-ci.org/docs/user/build-configuration/ to learn more

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: scala # to trigger the build on JVM worker ('language: java' works the same)
 env:
   - PLAY_VERSION=1.2.5
+  - POSTGIS=2.0
 services:
   - postgresql
 before_install:
+  - echo "yes" | sudo apt-add-repository ppa:ubuntugis/ubuntugis-unstable
   - sudo apt-get update -qq
-  - sudo apt-get install -qq postgis
+  - sudo apt-get install -qq libgeos-dev libgeos++-dev libproj-dev postgresql-9.1-postgis
 before_script: 
   # create spatially-enabled database
   - psql -c 'create database gtfs_editor;' -U postgres
-  - sudo -u postgres psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis-1.5/postgis.sql
-  - sudo -u postgres psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis-1.5/spatial_ref_sys.sql
-  - sudo -u postgres psql -d gtfs_editor < /usr/share/postgresql/9.1/contrib/postgis_comments.sql
+  - psql -U postgres -d gtfs_editor -c "CREATE EXTENSION postgis;"
   # get play framework
   - wget http://download.playframework.org/releases/play-${PLAY_VERSION}.zip
   - unzip -q play-${PLAY_VERSION}.zip 

--- a/conf/application.conf.template
+++ b/conf/application.conf.template
@@ -9,8 +9,6 @@ application.name=gtfs-editor
 application.mode=dev
 %prod.application.mode=prod
 
-module.secure=${play.path}/modules/secure
-
 # Secret key
 # ~~~~~
 # The secret key is used to secure cryptographics functions

--- a/conf/dependencies.yml
+++ b/conf/dependencies.yml
@@ -2,6 +2,7 @@
 
 require:
     - play
+    - play -> secure
     - com.typesafe.akka -> akka-actor 2.0.3
     - com.typesafe.akka -> akka-remote 2.0.3
     - gov.sandia.foundry -> gov-sandia-cognition-common-core 3.3.2


### PR DESCRIPTION
Attempting to run on play-1.2.5.3 gave the error:

```
Compilation error (In /app/controllers/Check.java around line 10)
The file /app/controllers/Check.java could not be compiled. Error raised is : The type Check is already defined
```

It had also first issued the warning:

```
WARN  ~ Declaring modules in application.conf is deprecated. Use dependencies.yml instead (module.secure)
```

So, I moved the `secure` module declaration into `dependencies.yml` and all is well.
