### PR TITLE
fix GIS route type export; fixes #225

### DIFF
--- a/app/jobs/GisExport.java
+++ b/app/jobs/GisExport.java
@@ -155,7 +155,7 @@ public class GisExport implements Runnable {
 						featureBuilder.add(r.routeDesc);
 
 						if (r.routeTypeId != null)
-							featureBuilder.add(gtx.routeTypes.get(r.routeTypeId).toString());
+							featureBuilder.add(gtx.routeTypes.get(r.routeTypeId).hvtRouteType);
 						else
 							featureBuilder.add("");
 


### PR DESCRIPTION
Changed `toString()` method for routeType (which no longer gives a valid routeType) to `hvtRouteType` string value.
