### PR TITLE
Backwards wrong count in backwards detection.

### DIFF
--- a/app/models/transit/TripPattern.java
+++ b/app/models/transit/TripPattern.java
@@ -355,7 +355,7 @@ public class TripPattern extends Model implements Cloneable, Serializable {
 			if (lastPos > 0) {
 				if (pos > lastPos)
 					backwards--;
-				else if (pos > lastPos)
+				else if (pos < lastPos)
 					backwards++;				
 			}
 			


### PR DESCRIPTION
Backwards counter was never increasing in case of distance decreasing (finding a stop behind the current stop).
